### PR TITLE
Removal of 'comment' and 'text' node types among other things

### DIFF
--- a/phoenix-browser/index.html
+++ b/phoenix-browser/index.html
@@ -1,57 +1,73 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <meta charset="utf-8">
-        <title>Privileged app</title>
-        <meta name="description" content="A privileged app stub">
+<head>
+    <meta charset="utf-8">
+    <title>Privileged app</title>
+    <meta name="description" content="A privileged app stub">
 
-        <!--
-          viewport allows you to control how mobile browsers will render your content.
-          width=device-width tells mobile browsers to render your content across the
-          full width of the screen, without being zoomed out (by default it would render
-          it at a desktop width, then shrink it to fit.)
-          Read more about it here:
-          https://developer.mozilla.org/Mozilla/Mobile/Viewport_meta_tag
-        -->
-        <meta name="viewport" content="width=device-width">
-        <link rel="stylesheet" href="css/reset.css">
-        <link rel="stylesheet" href="css/app.css">
+    <!--
+      viewport allows you to control how mobile browsers will render your content.
+      width=device-width tells mobile browsers to render your content across the
+      full width of the screen, without being zoomed out (by default it would render
+      it at a desktop width, then shrink it to fit.)
+      Read more about it here:
+      https://developer.mozilla.org/Mozilla/Mobile/Viewport_meta_tag
+    -->
+    <meta name="viewport" content="width=device-width">
+    <link rel="stylesheet" href="css/reset.css">
+    <link rel="stylesheet" href="css/app.css">
 
-        <!--
-        Inline JavaScript code is not allowed for privileged and certified apps,
-        due to Content Security Policy restrictions.
-        You can read more about it here: https://developer.mozilla.org/Apps/CSP
-        Plus keeping your JavaScript separated from your HTML is always a good practice!
-        We're also using the 'defer' attribute. This allows us to tell the browser that
-        it should not wait for this file to load before continuing to load the rest of
-        resources in the page. Then, once everything has been loaded, it will parse and
-        execute the deferred files.
-        Read about defer: https://developer.mozilla.org/Web/HTML/Element/script#attr-defer
-        -->
-        <script type="text/javascript" src="js/tab.js" defer></script>
-        <script type="text/javascript" src="js/app.js" defer></script>
+    <!--
+    Inline JavaScript code is not allowed for privileged and certified apps,
+    due to Content Security Policy restrictions.
+    You can read more about it here: https://developer.mozilla.org/Apps/CSP
+    Plus keeping your JavaScript separated from your HTML is always a good practice!
+    We're also using the 'defer' attribute. This allows us to tell the browser that
+    it should not wait for this file to load before continuing to load the rest of
+    resources in the page. Then, once everything has been loaded, it will parse and
+    execute the deferred files.
+    Read about defer: https://developer.mozilla.org/Web/HTML/Element/script#attr-defer
+    -->
+    <script type="text/javascript" src="js/tab.js" defer></script>
+    <script type="text/javascript" src="js/app.js" defer></script>
 
-        <!--
-        The following two lines are for loading the localisations library
-        and the localisation data-so people can use the app in their
-        own language (as long as you provide translations).
-        -->
-        <link rel="prefetch" type="application/l10n" href="data/locales.ini" />
-        <script type="text/javascript" src="js/libs/l10n.js" defer></script>
-    </head>
-    <body>
-        <!-- browser toolbar -->
-        <div id="toolbar">
-            <!-- <button id="goback-button" type="button" disabled>&lt;</button>
-            <button id="goforward-button" type="button" disabled>&gt;</button> -->
-            <!-- url bar displays page url or page title -->
-            <form id="url-bar">
-                <input id="url-input" type="text"></input>
-            <button id="url-button" form="url-bar">GO</button>
-            </form>
+    <!--
+    The following two lines are for loading the localisations library
+    and the localisation data-so people can use the app in their
+    own language (as long as you provide translations).
+    -->
+    <link rel="prefetch" type="application/l10n" href="data/locales.ini" />
+    <script type="text/javascript" src="js/libs/l10n.js" defer></script>
+</head>
+<body>
+<!-- Start test section -->
+<div id="test">
+    <div id="test2">
+        <div id="test3">
+            <div id="test4">
+                <div id="test5">
+                    <form id="formtest">
+                        <button id="testbutton"></button>
+                    </form>
+                </div>
+            </div>
         </div>
-        <!-- the container for the browser frame -->
-        <div id="frame-container" class="empty">
-        </div>
-    </body>
+    </div>
+</div>
+<img id="testimg"/>
+<!-- End test section -->
+<!-- browser toolbar -->
+<div id="toolbar">
+    <!-- <button id="goback-button" type="button" disabled>&lt;</button>
+    <button id="goforward-button" type="button" disabled>&gt;</button> -->
+    <!-- url bar displays page url or page title -->
+    <form id="url-bar">
+        <input id="url-input" type="text"/>
+        <button id="url-button" form="url-bar">GO</button>
+    </form>
+</div>
+<!-- the container for the browser frame -->
+<div id="frame-container" class="empty">
+</div>
+</body>
 </html>

--- a/phoenix-browser/js/app.js
+++ b/phoenix-browser/js/app.js
@@ -47,6 +47,7 @@ window.addEventListener('DOMContentLoaded', function() {
 
     if (!urlValidate.validity.valid) {
       var uri = searchEngineUri.replace('{searchTerms}', input);
+      uri = uri.replace(" ", "+");
       return uri;
     }
 
@@ -161,7 +162,7 @@ window.addEventListener('DOMContentLoaded', function() {
    * @param depth
    */
   function traverseDOMTree(targetDocument, currentElement, depth) {
-    if (currentElement) {
+    if (currentElement && currentElement.nodeType != 3 && currentElement.nodeType != 8) {
       var j;
       var tagName = currentElement.tagName;
       // Prints the node tagName, such as <A>, <IMG>, etc
@@ -169,9 +170,9 @@ window.addEventListener('DOMContentLoaded', function() {
       if (tagName) {
         domarray[domint++] = "&lt;" + currentElement.tagName + "&gt;";
         if (currentElement.id) {
-          targetDocument.writeln("Tag: " + "&lt;" + currentElement.tagName + "&gt;" + " Id: " + currentElement.id);
+          targetDocument.writeln("&lt;" + currentElement.tagName + "&gt;" + " Id: " + currentElement.id);
         } else {
-          targetDocument.writeln("Tag: " + "&lt;" + currentElement.tagName + "&gt;" + " Id: " + "No Id");
+          targetDocument.writeln("&lt;" + currentElement.tagName + "&gt;");
         }
       } else {
         targetDocument.writeln(currentElement.nodeName);
@@ -181,19 +182,22 @@ window.addEventListener('DOMContentLoaded', function() {
       var i = 0;
       var currentElementChild = currentElement.childNodes[i];
       while (currentElementChild) {
-        // Formatting code (indent the tree so it looks nice on the screen)
-        targetDocument.write("<BR>\n");
-        for (j = 0; j < depth; j++) {
-          // &#166 is just a vertical line
-          // &nbsp - non-breaking space
-          targetDocument.write("&nbsp;&nbsp;&#166");
+        if (currentElementChild.nodeType == 1) {
+          // Formatting code (indent the tree so it looks nice on the screen)
+          targetDocument.write("<BR>\n");
+          for (j = 0; j < depth; j++) {
+            // &#166 is just a vertical line
+            // &nbsp - non-breaking space
+            targetDocument.write("&nbsp;&nbsp;&#166");
+          }
+          targetDocument.writeln("<BR>");
+          for (j = 0; j < depth; j++) {
+            targetDocument.write("&nbsp;&nbsp;&#166");
+          }
+          if (tagName) {
+            targetDocument.write("--");
+          }
         }
-        targetDocument.writeln("<BR>");
-        for (j = 0; j < depth; j++) {
-          targetDocument.write("&nbsp;&nbsp;&#166");
-        }
-        if (tagName)
-          targetDocument.write("--");
 
         // Recursively traverse the tree structure of the child node
         traverseDOMTree(targetDocument, currentElementChild, depth + 1);
@@ -205,7 +209,7 @@ window.addEventListener('DOMContentLoaded', function() {
       for (j = 0; j < depth - 1; j++) {
         targetDocument.write("&nbsp;&nbsp;&#166");
       }
-      targetDocument.writeln("&nbsp;&nbsp;");
+      targetDocument.writeln("&nbsp;");
     }
     if (tagName) {
       domarray[domint++] = "&lt;/" + currentElement.tagName + "&gt;";
@@ -221,11 +225,12 @@ window.addEventListener('DOMContentLoaded', function() {
    */
 
   function printDOMTree(domElement, destinationWindow) {
-    // Use destination window to print the tree.  If destinationWIndow is
+    // Use destination window to print the tree.  If destinationWindow is
     // not specified, create a new window and print the tree into that window
     var outputWindow = destinationWindow;
-    if (!outputWindow)
+    if (!outputWindow) {
       outputWindow = window.open();
+    }
 
     // Make a valid html page
     outputWindow.document.open("text/html", "replace");


### PR DESCRIPTION
- Fixed some formatting, brackets, etc...
- Searching a phrase with spaces now places '+' in-between.
- Tree should now look a lot cleaner and easier to read.
- Tree ignores nodes of type 'comment' and 'text':
  https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType
- Added a test section to index.html
